### PR TITLE
Run with highest privilege available

### DIFF
--- a/TODO
+++ b/TODO
@@ -7,3 +7,5 @@ TODOs for OpenVPN-GUI
 * convert boolean registry values from string to dword
 * maybe parse config and use selected options in command line directly
 * have some kind of error log instead of message boxes for low level errors
+
+* remove external manifest

--- a/res/openvpn-gui-res.rc
+++ b/res/openvpn-gui-res.rc
@@ -29,8 +29,7 @@
 /* Language resource files are UTF-8 encoded */
 #pragma code_page(65001)
 
-/* Manifest for XP visual styles */
-CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "openvpn-gui.manifest"
+/* Manifest now distributed as external -- do not include here */
 
 /* Application Icons */
 ID_ICO_APP           ICON  DISCARDABLE  "openvpn-gui.ico"


### PR DESCRIPTION
Use an external manifest to allow the user to change the default executaion level.
Note: For this to work the manifest should not be embedded in the executable.

Signed-off-by: Selva Nair selva.nair@gmail.com
